### PR TITLE
Add minimal Chrome MV3 popup setup

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,5 @@
+const fs = require('fs');
+const path = require('path');
+fs.mkdirSync('dist', {recursive: true});
+fs.copyFileSync(path.join('src','popup.js'), path.join('dist','popup.js'));
+console.log('Build complete');

--- a/dist/popup.js
+++ b/dist/popup.js
@@ -1,0 +1,1 @@
+console.log('popup');

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+  "manifest_version": 3,
+  "name": "Scam Detector",
+  "version": "1.0.0",
+  "permissions": ["activeTab", "scripting", "storage"],
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "scam-detector",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "node build.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Popup</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="dist/popup.js"></script>
+</body>
+</html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,0 +1,1 @@
+console.log('popup');


### PR DESCRIPTION
## Summary
- set up simple build script and package
- add MV3 manifest with required permissions
- create popup.html loading `dist/popup.js`
- build script copies source to dist

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a9332bed88328860f208e3771a7a1